### PR TITLE
feat: add file watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -87,6 +87,18 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bon"
@@ -289,6 +301,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +470,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.9.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +533,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +575,42 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.9.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "num-traits"
@@ -651,6 +748,7 @@ dependencies = [
  "chrono",
  "clap",
  "json-resume",
+ "notify",
  "regex",
  "repo_path_lib",
  "serde_json",
@@ -667,6 +765,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
@@ -857,6 +964,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +1035,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -975,11 +1107,36 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -989,15 +1146,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1007,9 +1170,21 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1019,9 +1194,21 @@ checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1031,15 +1218,33 @@ checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ json-resume = { git = "https://github.com/jsonresume/rust-json-resume.git", vers
 regex = "1.11"
 repo_path_lib = "1.2"
 serde_json = "1.0"
+notify = "8.2"

--- a/resume.json
+++ b/resume.json
@@ -74,8 +74,8 @@
             "url": "https://paypal.com",
             "startDate": "2023-06-12",
             "highlights": [
-                "Maintained Braintree's Ruby on Rails app used to payout $1.5B a day across 15K merchants",
-                "Led development, coordinated live testing, and served as a subject matter expert for a feature used to withhold $1.5M a day from high-risk or delinquent merchants",
+                "Maintained Braintree's Ruby on Rails app used to payout $1.6B a day across 15K merchants",
+                "Led development, coordinated live testing, and served as a subject matter expert for a feature used to withhold $1.4M a day from high-risk or delinquent merchants",
                 "Automated a $57M migration in held funds to new banking partners and an updated internal ledger",
                 "Coordinated engineering effort to debug and resolve funds reconciliation issues, decreasing unreconciled funds by 88% and increasing reconciliation accuracy to 99.7%",
                 "Identified, reproduced, and fixed a regression caused by a Ruby on Rails upgrade, correcting over $80M in resulting misallocated funds",

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use std::fs::read_to_string;
 mod render;
 mod resume;
 mod typst;
+mod watcher;
 
 use render::Render;
 use resume::{ResumeFilterPredicate::*, ResumeSlice};
@@ -49,6 +50,11 @@ struct Args {
     #[arg(short, long)]
     /// If set, automatically remove all created intermediate artifacts, keeping the final render.
     clean: bool,
+
+    #[arg(short, long)]
+    /// If set, run the CLI in watch mode. This will automatically re-render the resume on changes
+    /// to the resume JSON specified in the `resume` argument.
+    watch: bool,
 }
 
 impl TryFrom<&Args> for RenderConfig {
@@ -84,10 +90,7 @@ fn read_resume(path: &Path) -> Result<Resume> {
 
 fn run_with_resume(args: &Args, f: fn(ResumeSlice) -> ResumeSlice) -> Result<()> {
     let resume = f(read_resume(Path::new(&args.resume))?.into());
-    let render_config: RenderConfig = args.try_into()?;
-
-    Typst.render(resume, &render_config)?;
-
+    Typst.render(resume, &args.try_into()?)?;
     Ok(())
 }
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,0 +1,73 @@
+use anyhow::{Error, Result};
+use camino::Utf8Path as Path;
+use camino::Utf8PathBuf as PathBuf;
+use notify::Event;
+use notify::EventKind;
+use notify::Watcher;
+use notify::event::DataChange;
+use notify::event::ModifyKind;
+use notify::event::RenameMode;
+use std::sync::mpsc;
+use std::sync::mpsc::Sender;
+
+struct ResumeWatcher {
+    resume_path: PathBuf,
+    sender: Sender<notify::Result<Event>>,
+    render: fn() -> Result<()>,
+}
+
+impl ResumeWatcher {
+    /// Dual process modifications to content to allow simultaneous renames to always win.
+    fn dual_process_event(&self, mut event: Event) -> Result<()> {
+        if let Some(info) = event.attrs.info()
+            && info == "seen"
+        {
+            (self.render)()?;
+            println!("rerendered!");
+        } else {
+            event.attrs.set_info("seen");
+            self.sender.send(Ok(event))?;
+        }
+
+        Ok(())
+    }
+
+    fn handle_event(&self, event: Event) -> Result<()> {
+        match event {
+            Event {
+                kind: EventKind::Modify(ModifyKind::Name(RenameMode::To)),
+                ..
+            } => Err(Error::msg("file rename detected, stopping"))?,
+            Event {
+                kind: EventKind::Modify(ModifyKind::Data(DataChange::Content)),
+                ..
+            } => self.dual_process_event(event),
+            _ => Ok(()),
+        }
+    }
+}
+
+pub fn watch(resume_path: &Path, render: fn() -> Result<()>) -> Result<()> {
+    let (tx, rx) = mpsc::channel::<notify::Result<Event>>();
+    let mut watcher = notify::recommended_watcher(tx.clone())?;
+    let resume_watcher = ResumeWatcher {
+        resume_path: resume_path.to_owned(),
+        sender: tx,
+        render,
+    };
+
+    watcher.watch(resume_path.as_ref(), notify::RecursiveMode::NonRecursive)?;
+
+    println!("watching for changes to {resume_path}");
+
+    for res in rx {
+        match res {
+            Ok(event) => resume_watcher.handle_event(event)?,
+            Err(e) => Err(Error::new(e).context(format!(
+                "error while watching changes to resume data: {resume_path}",
+            )))?,
+        }
+    }
+
+    Ok(())
+}

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,71 +1,46 @@
-use anyhow::{Error, Result};
+use anyhow::{Context, Error, Result};
 use camino::Utf8Path as Path;
-use camino::Utf8PathBuf as PathBuf;
 use notify::Event;
 use notify::EventKind;
 use notify::Watcher;
 use notify::event::DataChange;
 use notify::event::ModifyKind;
-use notify::event::RenameMode;
 use std::sync::mpsc;
-use std::sync::mpsc::Sender;
 
-struct ResumeWatcher {
-    resume_path: PathBuf,
-    sender: Sender<notify::Result<Event>>,
-    render: fn() -> Result<()>,
-}
-
-impl ResumeWatcher {
-    /// Dual process modifications to content to allow simultaneous renames to always win.
-    fn dual_process_event(&self, mut event: Event) -> Result<()> {
-        if let Some(info) = event.attrs.info()
-            && info == "seen"
-        {
-            (self.render)()?;
-            println!("rerendered!");
-        } else {
-            event.attrs.set_info("seen");
-            self.sender.send(Ok(event))?;
+fn handle<F>(event: Event, f: F) -> Result<()>
+where
+    F: Fn() -> Result<()>,
+{
+    match event {
+        Event {
+            kind: EventKind::Modify(ModifyKind::Data(DataChange::Content)),
+            ..
+        } => {
+            println!("content updated!");
+            f()
         }
-
-        Ok(())
-    }
-
-    fn handle_event(&self, event: Event) -> Result<()> {
-        match event {
-            Event {
-                kind: EventKind::Modify(ModifyKind::Name(RenameMode::To)),
-                ..
-            } => Err(Error::msg("file rename detected, stopping"))?,
-            Event {
-                kind: EventKind::Modify(ModifyKind::Data(DataChange::Content)),
-                ..
-            } => self.dual_process_event(event),
-            _ => Ok(()),
-        }
+        _ => Ok(()),
     }
 }
 
-pub fn watch(resume_path: &Path, render: fn() -> Result<()>) -> Result<()> {
+pub fn watch<F>(file_path: &Path, f: F) -> Result<()>
+where
+    F: Fn() -> Result<()>,
+{
     let (tx, rx) = mpsc::channel::<notify::Result<Event>>();
-    let mut watcher = notify::recommended_watcher(tx.clone())?;
-    let resume_watcher = ResumeWatcher {
-        resume_path: resume_path.to_owned(),
-        sender: tx,
-        render,
-    };
+    let mut watcher = notify::recommended_watcher(tx)
+        .map_err(Error::new)
+        .context("failed to create file watcher")?;
 
-    watcher.watch(resume_path.as_ref(), notify::RecursiveMode::NonRecursive)?;
+    watcher.watch(file_path.as_ref(), notify::RecursiveMode::NonRecursive)?;
 
-    println!("watching for changes to {resume_path}");
+    println!("watching for changes to {file_path}");
 
     for res in rx {
         match res {
-            Ok(event) => resume_watcher.handle_event(event)?,
-            Err(e) => Err(Error::new(e).context(format!(
-                "error while watching changes to resume data: {resume_path}",
-            )))?,
+            Ok(event) => handle(event, &f)?,
+            Err(e) => Err(Error::new(e)
+                .context(format!("error while watching changes to file: {file_path}",)))?,
         }
     }
 


### PR DESCRIPTION
This adds a basic file watcher which, while running, will trigger re-renders when it detects changes to the content of the resume JSON file.

The watcher can be enabled with the `-w` / `--watch` option, and respects all the other CLI arguments for rendering the resume.

File watching is implemented with the [`notify`](https://github.com/notify-rs/notify) crate.
